### PR TITLE
feat: sync from height in config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 .idea/
+.vscode/
 __debug_bin*
 quai-sync

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -47,6 +47,8 @@ func runCmd(_ *cobra.Command, _ []string) error {
 		cfg.Database.DSN,
 		cfg.Sync.DebugMode,
 		cfg.Sync.BatchSize,
+		cfg.Sync.IsFromConfig,
+		cfg.Sync.StartHeight,
 		cfg.GetLogLevel(),
 	)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -16,8 +16,10 @@ type Config struct {
 	} `mapstructure:"database"`
 
 	Sync struct {
-		BatchSize int  `mapstructure:"batch_size"`
-		DebugMode bool `mapstructure:"debug_mode"`
+		BatchSize    int  `mapstructure:"batch_size"`
+		DebugMode    bool `mapstructure:"debug_mode"`
+		IsFromConfig bool `mapstructure:"is_from_config"`
+		StartHeight  int  `mapstructure:"start_height"`
 	} `mapstructure:"sync"`
 }
 

--- a/config/config.toml
+++ b/config/config.toml
@@ -10,3 +10,5 @@ log_level = "silent"
 [sync]
 batch_size = 10
 debug_mode = false
+is_from_config = false
+start_height = 100

--- a/main.go
+++ b/main.go
@@ -19,9 +19,9 @@ func init() {
 
 func main() {
 	nodeURL := "https://rpc.quai.network/cyprus1/"
-	dbURL := "postgresql://postgres:1234@localhost:5432/quai?connect_timeout=100&sslmode=disable&TimeZone=UTC"
+	dbURL := "postgresql://postgres:123123@localhost:5432/quai?connect_timeout=100&sslmode=disable&TimeZone=UTC"
 
-	syncer, err := sync.NewBlockSync(nodeURL, dbURL, false, 5, logger.Info)
+	syncer, err := sync.NewBlockSync(nodeURL, dbURL, false, 5, true, 562484, logger.Info)
 	if err != nil {
 		log.Fatalf("Failed to create block syncer: %v", err)
 	}


### PR DESCRIPTION
Enable quai-syncer to sync starting from the height set in `config/config.toml`, skipping the blocks in the middle.
It will start syncing from the maximum of the highest height stored in database and the latest height of Quai.
If the height in config is greater than Quai, it will wait for Quai to catch up.